### PR TITLE
convert optional param without type annotation - fixes #1

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,12 @@
 export default function ({ Plugin, types: t }) {
   return new Plugin("flow-comments", {
     visitor: {
+      Identifier(node, parent, scope, file) {
+        if (!node.optional || node.typeAnnotation) {
+          return;
+        }
+        this.addComment("trailing", ":: ?");
+      },
       Flow(node, parent, scope, file) {
         var comment = this.getSource().replace("*/","//");
         if (parent.optional) comment = "?" + comment;

--- a/test/fixtures/optional-type/actual.js
+++ b/test/fixtures/optional-type/actual.js
@@ -1,1 +1,2 @@
-function foo(bar?: string) {}
+function foo(bar?) {}
+function foo2(bar?: string) {}

--- a/test/fixtures/optional-type/expected.js
+++ b/test/fixtures/optional-type/expected.js
@@ -1,3 +1,4 @@
 "use strict";
 
-function foo(bar /*:: ?: string*/) {}
+function foo(bar /*:: ?*/) {}
+function foo2(bar /*:: ?: string*/) {}


### PR DESCRIPTION
Fix to convert optional param only to a comment. #1

Had to check `node.typeAnnotation` as well since it was adding 2 comments (the flow visitor).

@ide @samwgoldman 