### PR TITLE
Also transform for ExportNamedDeclaration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,18 @@
 export default function ({ Plugin, types: t }) {
   return new Plugin("flow-comments", {
     visitor: {
+      // support function a(b?) {}
       Identifier(node, parent, scope, file) {
         if (!node.optional || node.typeAnnotation) {
           return;
         }
         this.addComment("trailing", ":: ?");
       },
-      Flow(node, parent, scope, file) {
+      "ExportNamedDeclaration|Flow"(node, parent, scope, file) {
+        // support `export type a = {}` - #8 Error: You passed path.replaceWith() a falsy node
+        if (t.isExportNamedDeclaration(node) && !t.isFlow(node.declaration)) {
+          return;
+        }
         var comment = this.getSource().replace("*/","//");
         if (parent.optional) comment = "?" + comment;
         if (comment[0] !== ":") comment = ":: " + comment;

--- a/test/fixtures/export-type-alias/actual.js
+++ b/test/fixtures/export-type-alias/actual.js
@@ -1,0 +1,7 @@
+export type GraphQLFormattedError = {
+  message: string,
+  locations?: Array<{
+    line: number,
+    column: number
+  }>
+};

--- a/test/fixtures/export-type-alias/expected.js
+++ b/test/fixtures/export-type-alias/expected.js
@@ -1,0 +1,13 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+/*:: export type GraphQLFormattedError = {
+  message: string,
+  locations?: Array<{
+    line: number,
+    column: number
+  }>
+};*/


### PR DESCRIPTION
fixes issue with `export type x = {}`
since it was only working with `type x = {}` before

Fixes #8 

Comment: https://github.com/babel-plugins/babel-plugin-flow-comments/issues/8#issuecomment-119042980

@leebyron - tested on `graphql-js` with no issues.