### PR TITLE
escape */ in comments correctly - Ref #6

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 export default function ({ Plugin, types: t }) {
   function wrapInFlowComment(context, parent) {
-    var comment = context.getSource().replace("*/","//");
+    var comment = context.getSource().replace(/\*-\//g, '*-ESCAPED/').replace(/\*\//g, '*-/');
     if (parent.optional) comment = "?" + comment;
     if (comment[0] !== ":") comment = ":: " + comment;
     context.addComment("trailing", comment);

--- a/test/fixtures/type-alias-with-comment/actual.js
+++ b/test/fixtures/type-alias-with-comment/actual.js
@@ -1,3 +1,5 @@
+type T = /*test*/ number;
+type T2 = /* *-/ */ number;
 type CustomType = {
 /** This is some documentation. */
 name: string;

--- a/test/fixtures/type-alias-with-comment/expected.js
+++ b/test/fixtures/type-alias-with-comment/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
+/*:: type T = /*test*-/ number;*/
+/*:: type T2 = /* *-ESCAPED/ *-/ number;*/
 /*:: type CustomType = {
-/** This is some documentation. //
+/** This is some documentation. *-/
 name: string;
 };*/


### PR DESCRIPTION
Ref #6 

@ide @jeffmo

~~- change *::/ to *::ESCAPED/~~
~~- change */ to *::/~~

- change *-/ to *-ESCAPED/
- change */ to *-/